### PR TITLE
Datagrid creation raise an error when collection is empty

### DIFF
--- a/src/Jfsimon/Datagrid/Infra/Extension/AbstractExtension.php
+++ b/src/Jfsimon/Datagrid/Infra/Extension/AbstractExtension.php
@@ -25,7 +25,7 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function guessSchema(Entity $entity, array $options)
+    public function guessSchema(Entity $entity = null, array $options)
     {
         return null;
     }

--- a/src/Jfsimon/Datagrid/Infra/Extension/CoreExtension.php
+++ b/src/Jfsimon/Datagrid/Infra/Extension/CoreExtension.php
@@ -30,7 +30,7 @@ class CoreExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function guessSchema(Entity $entity, array $options)
+    public function guessSchema(Entity $entity = null, array $options)
     {
         return isset($options['schema']) ? $options['schema'] : null;
     }

--- a/src/Jfsimon/Datagrid/Infra/Factory/Factory.php
+++ b/src/Jfsimon/Datagrid/Infra/Factory/Factory.php
@@ -86,8 +86,9 @@ class Factory implements FactoryInterface
 
         // schema building
         $schema = null;
+        $entity = $collection->getPeek();
         foreach ($extensions as $extension) {
-            $schema = $extension->guessSchema($collection->getPeek(), $options);
+            $schema = $extension->guessSchema($entity, $options);
             if (null !== $schema) {
                 break;
             }

--- a/src/Jfsimon/Datagrid/Service/ExtensionInterface.php
+++ b/src/Jfsimon/Datagrid/Service/ExtensionInterface.php
@@ -32,7 +32,7 @@ interface ExtensionInterface
      *
      * @return Schema|null
      */
-    public function guessSchema(Entity $entity, array $options);
+    public function guessSchema(Entity $entity = null, array $options);
 
     /**
      * Builds columns schema.

--- a/tests/Jfsimon/Datagrid/Tests/Infra/Factory/FactoryTest.php
+++ b/tests/Jfsimon/Datagrid/Tests/Infra/Factory/FactoryTest.php
@@ -44,9 +44,15 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateGridWithEmptyCollection()
     {
         $factory = new Factory();
+
         $collection = $this->getMock('Jfsimon\Datagrid\Model\Data\Collection', array(), array(), '', false);
         $collection->expects($this->once())->method('getPeek')->will($this->returnValue(null));
 
-        $this->assertInstanceOf('Jfsimon\Datagrid\Model\Component\Grid', $factory->createGrid($collection));
+        $schema = $this->getMock('Jfsimon\Datagrid\Model\Schema');
+
+        $this->assertInstanceOf(
+            'Jfsimon\Datagrid\Model\Component\Grid',
+            $factory->createGrid($collection, array('schema' => $schema))
+        );
     }
 }

--- a/tests/Jfsimon/Datagrid/Tests/Infra/Factory/FactoryTest.php
+++ b/tests/Jfsimon/Datagrid/Tests/Infra/Factory/FactoryTest.php
@@ -40,4 +40,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Jfsimon\Datagrid\Exception\ConfigurationException');
         $factory->createGrid(new Collection(array(array())));
     }
+
+    public function testCreateGridWithEmptyCollection()
+    {
+        $factory = new Factory();
+        $collection = $this->getMock('Jfsimon\Datagrid\Model\Data\Collection', array(), array(), '', false);
+        $collection->expects($this->once())->method('getPeek')->will($this->returnValue(null));
+
+        $this->assertInstanceOf('Jfsimon\Datagrid\Model\Component\Grid', $factory->createGrid($collection));
+    }
 }


### PR DESCRIPTION
When trying to create a datagrid with an empty collection, the following error is raised :

> Argument 1 passed to Jfsimon\Datagrid\Infra\Extension\CoreExtension::guessSchema() must be an instance of Jfsimon\Datagrid\Model\Data\Entity, null given, called in Jfsimon/Datagrid/Infra/Factory/Factory.php on line 90 and defined in Jfsimon/Datagrid/Infra/Extension/CoreExtension.php line 33 
